### PR TITLE
Use phenol `v2.1.1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <javafx.version>20.0.1</javafx.version>
         <hpotextmining.version>0.2.8</hpotextmining.version>
-        <phenol.version>2.0.1</phenol.version>
+        <phenol.version>2.1.1</phenol.version>
         <hpotextmining.version>0.2.7</hpotextmining.version>
         <junit.version>5.9.2</junit.version>
         <junit.launcher.version>1.8.1</junit.launcher.version>

--- a/src/main/java/org/monarchinitiative/phenotefx/smallfile/SmallFile.java
+++ b/src/main/java/org/monarchinitiative/phenotefx/smallfile/SmallFile.java
@@ -20,7 +20,6 @@ package org.monarchinitiative.phenotefx.smallfile;
  * #L%
  */
 
-import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +50,7 @@ public class SmallFile {
      */
     public SmallFile(String name, List<SmallFileEntry> entries) {
         basename=name;
-        originalEntryList = ImmutableList.copyOf(entries);
+        originalEntryList = List.copyOf(entries);
     }
 
     /** @return original {@link SmallFileEntry} objects -- one per line of the small file.*/


### PR DESCRIPTION
Use phenol `v2.1.1` to support obographs formats `>=0.3.1`, including the latest HPO releases.